### PR TITLE
Declare `rlang`, add R-CMD-check, release v0.1.0

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,0 +1,50 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+name: R-CMD-check.yaml
+
+permissions: read-all
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: macos-latest,   r: 'release'}
+          - {os: windows-latest, r: 'release'}
+          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,   r: 'release'}
+          - {os: ubuntu-latest,   r: 'oldrel-1'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: check
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true
+          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: spacehakr
 Title: Spatial Analysis, Raster Processing, and Geospatial Data Access
-Version: 0.0.0.9000
+Version: 0.1.0
 Authors@R: 
     person("Allan", "Irvine", , "al@newgraphenvironment.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-3495-2128"))
@@ -31,6 +31,7 @@ Imports:
     glue,
     httr2,
     purrr,
+    rlang,
     sf,
     stringr,
     terra,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,17 @@
+# spacehakr 0.1.0
+
+First tagged release. Twelve spatial functions extracted from `ngr`'s `ngr_spk_*`
+family — GDAL and OpenDroneMap command building, GeoServer WFS download, STAC
+raster math, spatial joins and raster utilities. See the
+[reference index](https://newgraphenvironment.github.io/spacehakr/reference/).
+
+This release exists so `ngr` has a pinnable version to depend on while it
+deprecates its own copies of these functions
+([ngr#7](https://github.com/NewGraphEnvironment/ngr/issues/7)).
+
+- Declare `rlang` in `Imports`. It was imported by `spk_join()` via
+  `@importFrom rlang .data` but never declared, so `R CMD check` failed with
+  `Namespace dependency missing from DESCRIPTION Imports/Depends entries`. This
+  went unnoticed because the package had no `R-CMD-check` workflow.
+- Add an `R-CMD-check` workflow, so the twelve test files run on every push
+  rather than never.


### PR DESCRIPTION
Prerequisite for [ngr#7](https://github.com/NewGraphEnvironment/ngr/issues/7), which deprecates ngr's twelve `ngr_spk_*` functions into shims that delegate here. ngr should not depend on an untagged package whose tests have never run in CI, so this cuts a pinnable `v0.1.0` and makes the tests actually run.

## What this found

`R CMD check` **fails on `main`**:

```
checking package dependencies ... ERROR
Namespace dependency missing from DESCRIPTION Imports/Depends entries: 'rlang'
```

`spk_join()` carries `#' @importFrom rlang .data` (R/spk_join.R:37), which puts `importFrom(rlang,.data)` in NAMESPACE, but `rlang` was never added to `Imports`. Nothing caught it because there is no `R-CMD-check` workflow — `pkgdown.yaml` installs via `local::.` and happens not to trip the same check.

Left alone, this would have surfaced as a broken install in ngr rather than here.

## Changes

- **`DESCRIPTION`** — declare `rlang` in `Imports`; bump `0.0.0.9000` → `0.1.0`
- **`.github/workflows/R-CMD-check.yaml`** — the standard r-lib check workflow, so the twelve test files run on every push
- **`NEWS.md`** — new, recording the above

## Verification

```
devtools::test()   [ FAIL 0 | WARN 1 | SKIP 2 | PASS 126 ]
devtools::check(vignettes = FALSE)   0 errors | 0 warnings | 1 note
```

The remaining NOTE is `checking Rd line widths` — cosmetic.

The one WARN is pre-existing, at `test-spk_stac_calc.R:209`: the test asserts an error from `terra::rast("https://example.com/visual.tif")` and GDAL reports the 404 as a warning on the way. Its regex (`"cannot open|HTTP|curl"`) matches the offline failure too, so it is not network-fragile in CI. Left as-is — out of scope here, worth its own issue if it becomes noisy.

## After merge

Tag the release, which is what ngr's `Remotes:` pin resolves against:

```bash
git checkout main && git pull
git tag v0.1.0 && git push --tags
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TwfyioBFt9bBe8xie4LWfi
